### PR TITLE
Transport parameter and trigger version

### DIFF
--- a/draft-thomson-train-protocol.md
+++ b/draft-thomson-train-protocol.md
@@ -151,7 +151,6 @@ number of send rates, as shown in {{table-rates}}.
 
 | Rate Limit | Version 1 | Version 2 |
 |--:|:--|:--|
-| trigger    | 0xTBD | 0xTBD |
 | 1Mbps      | 0xTBD | 0xTBD |
 | 2Mbps      | 0xTBD | 0xTBD |
 | 3Mbps      | 0xTBD | 0xTBD |
@@ -200,10 +199,9 @@ indication.
 
 The TRAIN extension requires cooperation between the two endpoints. Each endpoint
 indicates its willingness to receive long header packets by negotiating the
-support of one of the QUIC "trigger" versions, as defined in {{QUIC-VN}}.
+support the QUIC TRAIN version, as defined in {{QUIC-VN}}.
 Once the version has been negotiated, endpoints will use it in long
-header packets, as defined is {{QUIC-TRANSPORT}} or {{QUIC-V2}}
-respectively.
+header packets.
 
 Negotiating one of the trigger versions implies support for the
 TRAIN_BANDWIDTH frame (see {{tbwf}}).

--- a/draft-thomson-train-protocol.md
+++ b/draft-thomson-train-protocol.md
@@ -183,17 +183,9 @@ But the 4 bytes of the version number will be restored to 0x6b3343cf before
 attempting to process the packet further.
 
 The "trigger" version used by the endpoints when sending long header packets
-that on-path network elements are authorized to rewrite. receiving packets
+that on-path network elements are authorized to rewrite. Receiving packets
 with that value indicates that no on-path element provided a bandwidth
 indication.
-
-{:aside}
-> TODO: we should indicate that the bandwidth here is the maximum
-> receive rate. That is, if A sends a long header packet and B receives
-> that packet with a version encoding the bandwidth, that version
-> indicates the maximum rate at which B can send and A can receive.
-> That way we don't need B to echo a max send rate value to A.
-
 
 # Onboarding the train {#nego}
 
@@ -266,6 +258,7 @@ value in a TRAIN_BANDWIDTH frame.
 TRAIN_BANDWIDTH Frame {
   Type (i) = 0x15228c0c,
   Path Identifier (i),
+  Bandwidth (i)
 }
 ~~~
 {: #fig-train-bandwidth-frame title="TRAIN_BANDWIDTH Frame Format"}

--- a/draft-thomson-train-protocol.md
+++ b/draft-thomson-train-protocol.md
@@ -29,6 +29,10 @@ author:
     email: mt@lowentropy.net
 
 normative:
+  QUIC-TRANSPORT: rfc9000
+  QUIC-V2: rfc9369
+  QUIC-VN: rfc9368
+
 
 informative:
 
@@ -195,11 +199,14 @@ indication.
 # Onboarding the train {#nego}
 
 The TRAIN extension requires cooperation between the two endpoints. Each endpoint
-indicates its willingness to receive long header packets by publishing
-the "train-station-ready" transport parameter (TBD), which a zero length value.
+indicates its willingness to receive long header packets by negotiating the
+support of one of the QUIC "trigger" versions, as defined in {{QUIC-VN}}.
+Once the version has been negotiated, endpoints will use it in long
+header packets, as defined is {{QUIC-TRANSPORT}} or {{QUIC-V2}}
+respectively.
 
-Endpoint MAY set the version field of long header packets to the trigger
-value if the peer has published the "train-station-ready" parameter.
+Negotiating one of the trigger versions implies support for the
+TRAIN_BANDWIDTH frame (see {{tbwf}}).
 
 # Deployment
 
@@ -250,6 +257,26 @@ An endpoint that receives and discards a packet when there are no valid packets
 in the datagram SHOULD ignore any rate limit signal.  Such a datagram might be
 entirely spoofed.
 
+# The TRAIN BANDWIDTH frame {#tbwf}
+
+The rate limit designated by one of the reserved version values indicates
+the rate limit for packets sent in that direction of transport. The endpoint
+receiving the indication SHOULD forward it to the peer by posting the
+value in a TRAIN_BANDWIDTH frame.
+
+~~~
+TRAIN_BANDWIDTH Frame {
+  Type (i) = 0x15228c0c,
+  Path Identifier (i),
+}
+~~~
+{: #fig-train-bandwidth-frame title="TRAIN_BANDWIDTH Frame Format"}
+
+{:aside}
+> TODO: how do we identify the path exactly?
+> do we need some kind of ordering, to make sure that
+> the receiver only keeps the latest version?
+> Probably needs to specify repeat rules.
 
 
 # Security Considerations

--- a/draft-thomson-train-protocol.md
+++ b/draft-thomson-train-protocol.md
@@ -147,6 +147,7 @@ number of send rates, as shown in {{table-rates}}.
 
 | Rate Limit | Version 1 | Version 2 |
 |--:|:--|:--|
+| trigger    | 0xTBD | 0xTBD |
 | 1Mbps      | 0xTBD | 0xTBD |
 | 2Mbps      | 0xTBD | 0xTBD |
 | 3Mbps      | 0xTBD | 0xTBD |
@@ -178,6 +179,27 @@ cfXXXXXXXX0008f067a5502a4262b574 6f6b656ec8646ce8bfe33952d9555436
 But the 4 bytes of the version number will be restored to 0x6b3343cf before
 attempting to process the packet further.
 
+The "trigger" version used by the endpoints when sending long header packets
+that on-path network elements are authorized to rewrite. receiving packets
+with that value indicates that no on-path element provided a bandwidth
+indication.
+
+{:aside}
+> TODO: we should indicate that the bandwidth here is the maximum
+> receive rate. That is, if A sends a long header packet and B receives
+> that packet with a version encoding the bandwidth, that version
+> indicates the maximum rate at which B can send and A can receive.
+> That way we don't need B to echo a max send rate value to A.
+
+
+# Onboarding the train {#nego}
+
+The TRAIN extension requires cooperation between the two endpoints. Each endpoint
+indicates its willingness to receive long header packets by publishing
+the "train-station-ready" transport parameter (TBD), which a zero length value.
+
+Endpoint MAY set the version field of long header packets to the trigger
+value if the peer has published the "train-station-ready" parameter.
 
 # Deployment
 
@@ -193,6 +215,7 @@ modification as damage and discard the packet.
 > TODO: do we need to define a new QUIC version where support for that version
 > also indicates support for this feature?  That might allow endpoints to know
 > that their long header packets, if modified, won't get dropped.
+> YES: see "trigger" above.
 
 {:aside}
 > TODO: determine whether we want a frame that solicits the sending of a long


### PR DESCRIPTION
This PR proposes:

* define a "trigger" version,
* use a transport parameter to indicate support of the feature,
* hint that we need to add text specifying use of trigger version by routers